### PR TITLE
auth_failure arguments fixed

### DIFF
--- a/bin/openvpn-auth.py
+++ b/bin/openvpn-auth.py
@@ -18,9 +18,9 @@ def auth_success(username):
     exit(0)
     
 
-def auth_failure(reason):
+def auth_failure(reason, severity="INFO"):
     """ Authentication failure, rejecting login with a stderr reason """
-    print >> sys.stderr, "[INFO] OpenVPN Authentication failure : " + reason
+    print >> sys.stderr, "["+severity+"] OpenVPN Authentication failure : " + reason
     exit(1)
 
 def auth_ldap(address, basedn, binddn, bindpwd, search, username, password):


### PR DESCRIPTION
I've got this exception:

``` python
Traceback (most recent call last):
File "/usr/local/bin/openvpn-auth.py", line 118, in <module>
    auth_ldap(address, basedn, binddn, bindpwd, search, username, password)
File "/usr/local/bin/openvpn-auth.py", line 68, in auth_ldap
    auth_failure("Server unreachable",'ERROR')
TypeError: auth_failure() takes exactly 1 argument (2 given)
```
