### PR TITLE
Support authentication against a rancher server

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Current version is shipped with following authentication :
 - httpbasic
 - httpdigest
 - ldap
+- rancherlocal
 
 ---
 
@@ -152,6 +153,22 @@ docker run -d --privileged=true -p 1194:1194 --link ldap:ldapsrv \
     mdns/rancher-openvpn
 ```
 ---
+
+### Rancher Server in local mode
+
+Authentication is made by trying to connect to a Rancher Server configured in local mode.
+
+Each variable is mandatory :
+- AUTH_METHOD=rancherlocal
+- AUTH_HTTPBASIC_URL is the http server url, ex : AUTH_HTTPBASIC_URL='http[s]://hostname[:port]/v1/token'
+
+You can test authentication against the Rancher api server :
+```sh
+docker run -d --privileged=true -p 1194:1194 \
+    -e AUTH_METHOD=rancherlocal \
+    -e AUTH_HTTPBASIC_URL=https://rancher.example.com/v1/token \
+    mdns/rancher-openvpn
+```
 
 ## Client configuration
 

--- a/bin/openvpn-auth.py
+++ b/bin/openvpn-auth.py
@@ -90,6 +90,12 @@ def auth_http_digest(url, username, password):
     else:
         auth_failure("Invalid credentials for username "+ username)
 
+def auth_rancher_local(url, username, password):
+    if (requests.post(url, data = { "authProvider": "localauthconfig", "code": username + ":" + password})):
+        auth_success(username)
+    else:
+        auth_failure("Invalid credentials for username "+ username)
+
 if all (k in os.environ for k in ("username","password","AUTH_METHOD")):
     username = os.environ.get('username') 
     password = os.environ.get('password') 
@@ -146,6 +152,19 @@ if all (k in os.environ for k in ("username","password","AUTH_METHOD")):
             auth_http_digest(url, username, password)
         else:
             auth_failure('Missing mandatory environment variable for authentication method "httpdigest" : AUTH_HTTPDIGEST_URL')
+
+    #=====[ Rancher local ]==============================================================
+    # How to test:
+    #   @todo
+    # Example :
+    #   AUTH_METHOD='rancherlocal'
+    elif auth_method=='rancherlocal':
+        if "AUTH_RANCHERLOCAL_URL" in os.environ:
+            url=os.environ.get('AUTH_RANCHERLOCAL_URL')
+            auth_rancher_local(url, username, password)
+        else:
+            auth_failure('Missing mandatory environment variable for authentication method "httpbasic" : AUTH_RANCHERLOCAL_URL')
+
             
     #=====[ Kerberos ]==============================================================
     # How to test:

--- a/bin/openvpn-auth.py
+++ b/bin/openvpn-auth.py
@@ -163,7 +163,7 @@ if all (k in os.environ for k in ("username","password","AUTH_METHOD")):
             url=os.environ.get('AUTH_RANCHERLOCAL_URL')
             auth_rancher_local(url, username, password)
         else:
-            auth_failure('Missing mandatory environment variable for authentication method "httpbasic" : AUTH_RANCHERLOCAL_URL')
+            auth_failure('Missing mandatory environment variable for authentication method "rancherlocal" : AUTH_RANCHERLOCAL_URL')
 
             
     #=====[ Kerberos ]==============================================================


### PR DESCRIPTION
This patch enables 'rancherlocal' authentication method to hit a Rancher 1.x server running in local auth mode. 
