### PR TITLE
Check for empty password

### DIFF
--- a/bin/openvpn-auth.py
+++ b/bin/openvpn-auth.py
@@ -36,7 +36,10 @@ def auth_ldap(address, basedn, binddn, bindpwd, search, username, password):
     conn.set_option(ldap.OPT_REFERRALS, 0)
         
     # Trying authentication
-    try:    
+    try:
+        if(password is None or password==''):
+            auth_failure('Password is required')
+            
         # if server need authentication to be crawled
         if(binddn is not None and binddn!=''):
             conn.simple_bind_s(binddn, bindpwd)


### PR DESCRIPTION
A correct username with an empty password can successfully be bound to a default Active Directory configuration. This check for an empty password prevents this security issue.
Here some tests wit AD authentication: https://github.com/BorisMorel/LdapBundle/issues/36#issuecomment-8755660
